### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A Model Context Protocol (MCP) server for accessing N Lobby school portal data. This server provides secure access to school information including announcements, schedules, and learning resources through browser-based authentication.
 
+<a href="https://glama.ai/mcp/servers/@minagishl/nlobby-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@minagishl/nlobby-mcp/badge" alt="N Lobby Server MCP server" />
+</a>
+
 ## Features
 
 - **Browser-based Authentication**: Interactive login via automated browser window


### PR DESCRIPTION
This PR adds a badge for the [N Lobby MCP Server](https://glama.ai/mcp/servers/@minagishl/nlobby-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@minagishl/nlobby-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@minagishl/nlobby-mcp/badge" alt="N Lobby Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.